### PR TITLE
Add 'bouncy castle licence' and 'the (new) bsd license'

### DIFF
--- a/helpers/policy.json
+++ b/helpers/policy.json
@@ -4018,6 +4018,7 @@
         "mit license": "MIT",
         "the mit license": "MIT",
         "mit-0": "MIT-0",
+        "bouncy castle licence": "MIT",
         
         "bsd": "BSD-3-Clause",
         "bsd license": "BSD-3-Clause",
@@ -4053,6 +4054,7 @@
         
         "bsd new license": "BSD-3-Clause",
         "new bsd": "BSD-3-Clause",
+        "the (new) bsd license": "BSD-3-Clause",
         
         "public domain, per creative commons cc0": "CC0-1.0",
         "public domain, per creative commons cc0 and bsd-2-clause": "CC0-1.0",


### PR DESCRIPTION
Add "bouncy castle license" as an alias for MIT. (https://www.bouncycastle.org/licence.html, especially "Please note the Bouncy Caste License should be read in the same way as the [MIT license](http://opensource.org/licenses/MIT).".
also add "the (new) bsd license" as an alias for BSD 3 clause.