### PR TITLE
Add CDDL-1.1 mapping for cddl/gplv2+ce license

### DIFF
--- a/helpers/policy.json
+++ b/helpers/policy.json
@@ -4061,7 +4061,8 @@
     },
     "combinedLicenseAliases": {
         "_comment": "Mapping of combined/dual license expressions to a preferred single license. Keys are lowercase.",
-        
+
+        "cddl/gplv2+ce": "CDDL-1.1",
         "cddl + gplv2": "CDDL-1.1",
         "cddl+gplv2": "CDDL-1.1",
         "cddl + gplv2 with classpath exception": "CDDL-1.1",


### PR DESCRIPTION
appeared in https://github.com/otto-ec/hellfish_metricscollector/actions/runs/21472980244
following the pattern from "combinedLicenseAliases".