### PR TITLE
Allow BlueOak-1.0.0 license

### DIFF
--- a/helpers/policy.json
+++ b/helpers/policy.json
@@ -3305,11 +3305,11 @@
         {
             "id": "BlueOak-1.0.0",
             "name": "BlueOak-1.0.0",
-            "family": "dummy255",
+            "family": "BlueOak",
             "reference": "https://spdx.org/licenses/BlueOak-1.0.0.html",
-            "usagePolicy": "deny",
+            "usagePolicy": "allow",
             "annotationRefs": [
-                "PROHIBITED"
+                "APPROVED"
             ],
             "urls": [
                 ""


### PR DESCRIPTION
This PR allows the BlueOak-1.0.0 license as requested.

According to the internal list from the legal department, BlueOak should be allowed.

Fixes #10