### PR TITLE
Allow Python-2.0, Dnspython, Saxpath, and Zope Public Licenses

### DIFF
--- a/helpers/policy.json
+++ b/helpers/policy.json
@@ -2020,9 +2020,9 @@
             "name": "Python-2.0",
             "family": "Python-2.0",
             "reference": "https://spdx.org/licenses/Python-2.0.html",
-            "usagePolicy": "deny",
+            "usagePolicy": "allow",
             "annotationRefs": [
-                "PROHIBITED"
+                "APPROVED"
             ],
             "urls": [
                 ""
@@ -2044,11 +2044,11 @@
         {
             "id": "Saxpath",
             "name": "Saxpath",
-            "family": "dummy158",
+            "family": "Saxpath",
             "reference": "https://spdx.org/licenses/Saxpath.html",
-            "usagePolicy": "deny",
+            "usagePolicy": "allow",
             "annotationRefs": [
-                "PROHIBITED"
+                "APPROVED"
             ],
             "urls": [
                 ""
@@ -2332,9 +2332,9 @@
             "name": "ZPL-2.0",
             "family": "ZPL",
             "reference": "https://spdx.org/licenses/ZPL-2.0.html",
-            "usagePolicy": "deny",
+            "usagePolicy": "allow",
             "annotationRefs": [
-                "PROHIBITED"
+                "APPROVED"
             ],
             "urls": [
                 ""
@@ -2345,9 +2345,9 @@
             "name": "ZPL-2.1",
             "family": "ZPL",
             "reference": "https://spdx.org/licenses/ZPL-2.1.html",
-            "usagePolicy": "deny",
+            "usagePolicy": "allow",
             "annotationRefs": [
-                "PROHIBITED"
+                "APPROVED"
             ],
             "urls": [
                 ""
@@ -4048,6 +4048,7 @@
         
         "isc license": "ISC",
         "the isc license": "ISC",
+        "dnspython license": "ISC",
         
         "unlicense": "Unlicense",
         "the unlicense": "Unlicense",


### PR DESCRIPTION
This PR allows the following licenses as requested:

- **Python-2.0**: Used by argparse@2.0.1
- **Saxpath**: Used by mccabe@0.7.0
- **ZPL-2.0 / ZPL-2.1** (Zope Public License): Used by datetime@6.0
- **Dnspython license**: Added as alias for ISC (dnspython >= 2.2.1)

According to the internal list from the legal department, these should be allowed. Decision was made on 3.2.2026.

Fixes #14