### PR TITLE
feat: allow CC-BY-2.0 / CC-BY-3.0 / CC-BY-4.0 licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2026-02-12
+
+### Added
+- **New Allowed Licenses** (approved by legal department):
+  - CC-BY-2.0 (Creative Commons Attribution 2.0) (#17)
+  - CC-BY-3.0 (Creative Commons Attribution 3.0) (#17)
+  - CC-BY-4.0 (Creative Commons Attribution 4.0) (#17)
+  - Updated compound expression `CC-BY-4.0 AND MIT AND Apache-2.0` to allowed (#17)
+
 ## [1.0.0] - 2026-02-06
 
 ### Added

--- a/helpers/policy.json
+++ b/helpers/policy.json
@@ -1236,6 +1236,45 @@
             ]
         },
         {
+            "id": "CC-BY-2.0",
+            "name": "CC-BY-2.0",
+            "family": "CC-BY",
+            "reference": "https://spdx.org/licenses/CC-BY-2.0.html",
+            "usagePolicy": "allow",
+            "annotationRefs": [
+                "APPROVED"
+            ],
+            "urls": [
+                ""
+            ]
+        },
+        {
+            "id": "CC-BY-3.0",
+            "name": "CC-BY-3.0",
+            "family": "CC-BY",
+            "reference": "https://spdx.org/licenses/CC-BY-3.0.html",
+            "usagePolicy": "allow",
+            "annotationRefs": [
+                "APPROVED"
+            ],
+            "urls": [
+                ""
+            ]
+        },
+        {
+            "id": "CC-BY-4.0",
+            "name": "CC-BY-4.0",
+            "family": "CC-BY",
+            "reference": "https://spdx.org/licenses/CC-BY-4.0.html",
+            "usagePolicy": "allow",
+            "annotationRefs": [
+                "APPROVED"
+            ],
+            "urls": [
+                ""
+            ]
+        },
+        {
             "id": "CFITSIO",
             "name": "CFITSIO",
             "family": "dummy96",
@@ -3708,11 +3747,11 @@
         {
             "id": "CC-BY-4.0 AND MIT AND Apache-2.0",
             "name": "CC-BY-4.0 AND MIT AND Apache-2.0",
-            "family": "dummy286",
+            "family": "CC-BY",
             "reference": "",
-            "usagePolicy": "deny",
+            "usagePolicy": "allow",
             "annotationRefs": [
-                "PROHIBITED"
+                "APPROVED"
             ],
             "urls": [
                 ""


### PR DESCRIPTION
## Summary

Adds Creative Commons Attribution licenses (CC-BY-2.0, CC-BY-3.0, CC-BY-4.0) to the allowed license list, as approved by the legal department.

Closes #17

## Changes

### `helpers/policy.json`
- Added **CC-BY-2.0** as allowed (family: CC-BY)
- Added **CC-BY-3.0** as allowed (family: CC-BY)
- Added **CC-BY-4.0** as allowed (family: CC-BY)
- Updated compound expression **`CC-BY-4.0 AND MIT AND Apache-2.0`** from `deny` to `allow` (since all constituent licenses are now approved)

### `CHANGELOG.md`
- Added v1.1.0 entry documenting the new allowed licenses

## Affected packages (from issue)

| Package | License | New Policy |
| :--- | :--- | :--- |
| `spdx-exceptions@2.5.0` | CC-BY-3.0 | allow |
| `caniuse-lite@1.0.30001701` | CC-BY-4.0 | allow |
| `caniuse-lite@1.0.30001655` | CC-BY-4.0 | allow |

## Testing

All 63 existing tests pass without changes.